### PR TITLE
Update configure.ac to make it install PAM modules in the right place on Gentoo, thus making pam-gnupg actually work on Gentoo.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,8 @@ AM_PROG_AR
 LT_INIT
 
 AC_ARG_WITH([moduledir], AS_HELP_STRING([--with-moduledir=PATH],
-            [Path where PAM modules are to be installed [[/lib/security]]]),
-            [moduledir="$withval"], [moduledir="/lib/security"])
+            [Path where PAM modules are to be installed [[/lib64/security]]]),
+            [moduledir="$withval"], [moduledir="/lib64/security"])
 AC_SUBST(moduledir)
 
 AC_CHECK_HEADERS([security/pam_modules.h], [have_pamheader="yes"])


### PR DESCRIPTION
Hi, 

This little change makes it so that pam-gnupg actually works on Gentoo. 
It works by installing the PAM modules where PAM expects them to be on Gentoo.
By default, the moduledir is set to /lib/security, but PAM on Gentoo expects /lib64/security
I would not recommend merging this PR because this might break pam-gnupg on other distros. 
I think that a better solution is to let Gentoo users know that that this script doesn't install things in the right place on Gentoo and to inform Gentoo users of this simple fix in the README. 
This fix might even fix all the other Gentoo-related issues here.

Sincerely,

Abdul
